### PR TITLE
Fix a11y test by restoring css-loader v7 default for CSS Modules

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -63,6 +63,14 @@ const config: StorybookConfig = {
           options: {
             modules: {
               localIdentName: '[name]__[local]--[hash:base64:5]',
+              // css-loader v7 changed defaults to `namedExport: true` and
+              // `exportLocalsConvention: 'camelCaseOnly'`, which breaks the
+              // `import styles from './Foo.module.css'` + `styles.helperText`
+              // pattern used by components in this repo (locals end up as
+              // named exports rather than on the default export). Restore the
+              // legacy behavior so default-import access keeps working.
+              namedExport: false,
+              exportLocalsConvention: 'as-is',
             },
           },
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18701,22 +18701,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18701,7 +18701,22 @@
         }
       }
     },
-    "node_modules/w3c-xmlserializer": {
+    "node_modules/vitest/node_modules/yaml": { 
+       "version": "2.8.3", 
+       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz", 
+       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==", 
+       "extraneous": true, 
+       "license": "ISC", 
+       "bin": { 
+         "yaml": "bin.mjs" 
+       }, 
+       "engines": { 
+         "node": ">= 14.6" 
+       }, 
+       "funding": { 
+         "url": "https://github.com/sponsors/eemeli" 
+       } 
+     },"node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",


### PR DESCRIPTION
This pull request updates the Storybook Webpack configuration to restore legacy CSS Modules export behavior, ensuring compatibility with how components in the repository import and use CSS module styles.

**Storybook CSS Modules configuration:**

* Updated the `css-loader` options in `.storybook/main.ts` to set `namedExport: false` and `exportLocalsConvention: 'as-is'`, restoring the default-export pattern for CSS modules and preventing breaking changes introduced by `css-loader` v7.<!--

## Summary by Sourcery

Build:
- Update Storybook Webpack css-loader configuration to disable named exports and use 'as-is' locals convention for CSS Modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS module styling configuration in Storybook to restore proper import behavior for component stories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->