### PR TITLE
feat: add destructive alias and update documentation

### DIFF
--- a/demo/src/sections/Button.tsx
+++ b/demo/src/sections/Button.tsx
@@ -18,6 +18,8 @@ export function ButtonSection() {
           <Button variant="outline">Outline</Button>
           <Button variant="ghost">Ghost</Button>
           <Button variant="danger">Danger</Button>
+          <Button variant="destructive">Destructive</Button>
+          
         </div>
       </Scenario>
       <Scenario title="Sizes">

--- a/demo/src/sections/Button.tsx
+++ b/demo/src/sections/Button.tsx
@@ -8,7 +8,7 @@ export function ButtonSection() {
     <Section
       id="button"
       name="Button"
-      description="Primary action primitive — six variants, three sizes, icon slots and loading state."
+      description="Primary action primitive — six variants (plus the `destructive` alias for `danger`), three sizes, icon slots and loading state."
     >
       <Scenario title="Variants">
         <div className="row">
@@ -19,7 +19,6 @@ export function ButtonSection() {
           <Button variant="ghost">Ghost</Button>
           <Button variant="danger">Danger</Button>
           <Button variant="destructive">Destructive</Button>
-          
         </div>
       </Scenario>
       <Scenario title="Sizes">

--- a/src/components/actions/Button/Button.stories.tsx
+++ b/src/components/actions/Button/Button.stories.tsx
@@ -95,6 +95,19 @@ export const Disabled: Story = {
     </div>
   ),
 };
+export const Destructive: Story = {
+  args: {
+    variant: 'destructive',
+    children: 'Delete',
+  },
+};
+
+export const AsChild: Story = {
+  args: {
+    asChild: true,
+    children: <a href="#">Custom Link</a>,
+  },
+};
 
 export const FullWidth: Story = {
   args: { children: 'Full width', fullWidth: true },

--- a/src/components/actions/Button/Button.stories.tsx
+++ b/src/components/actions/Button/Button.stories.tsx
@@ -2,12 +2,34 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Button } from './Button';
 import { PlusIcon, ChevronDownIcon, CloseIcon } from '../../../icons';
-import { LocaleLink } from '../../../navigation/LocaleLink'; // Додано імпорт
+
+// Local stub used to demonstrate Radix-style `asChild` composition with a
+// custom routing component (e.g. a localized `<Link>`). Replace with your
+// app's link component in real usage.
+const LocaleLink = React.forwardRef<
+  HTMLAnchorElement,
+  React.AnchorHTMLAttributes<HTMLAnchorElement>
+>(function LocaleLink(props, ref) {
+  return <a ref={ref} {...props} />;
+});
 
 const meta: Meta<typeof Button> = {
   title: 'Components/Actions/Button',
   component: Button,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Action primitive whose visual styling is owned by the component and driven by design tokens ' +
+          '(CSS custom properties such as `--zp-color-*`, `--zp-space-*`, `--zp-radius-*`). ' +
+          'Compose and extend via the `variant`, `size`, `fullWidth`, `iconOnly`, and `asChild` props ' +
+          'rather than redeclaring Tailwind class strings. Use `className` only for layout-level overrides; ' +
+          'do not duplicate token-driven styles. The `destructive` variant is an alias of `danger` and ' +
+          'renders with the same token-backed styles.',
+      },
+    },
+  },
   argTypes: {
     variant: {
       control: 'select',
@@ -37,7 +59,7 @@ export const Variants: Story = {
       <Button variant="outline">Outline</Button>
       <Button variant="ghost">Ghost</Button>
       <Button variant="danger">Danger</Button>
-      <Button variant="destructive">Destructive</Button> {/* Додано */}
+      <Button variant="destructive">Destructive</Button>
     </div>
   ),
 };
@@ -100,7 +122,13 @@ export const Disabled: Story = {
 
 export const Destructive: Story = {
   parameters: {
-    docs: { description: { story: 'Alias for the `danger` variant, used for destructive actions.' } }
+    docs: {
+      description: {
+        story:
+          '`destructive` is an alias for `danger` and renders with the same `variant-danger` token-driven styles. ' +
+          'Use whichever name better fits your product vocabulary; both produce identical output.',
+      },
+    },
   },
   args: {
     variant: 'destructive',
@@ -112,9 +140,10 @@ export const AsChild: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Demonstrates polymorphic composition using `asChild`. Example uses a custom `LocaleLink` component.'
-      }
-    }
+        story:
+          'Demonstrates polymorphic composition using `asChild`. Example uses a custom `LocaleLink` component.',
+      },
+    },
   },
   args: {
     asChild: true,

--- a/src/components/actions/Button/Button.stories.tsx
+++ b/src/components/actions/Button/Button.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Button } from './Button';
 import { PlusIcon, ChevronDownIcon, CloseIcon } from '../../../icons';
+import { LocaleLink } from '../../../navigation/LocaleLink'; // Додано імпорт
 
 const meta: Meta<typeof Button> = {
   title: 'Components/Actions/Button',
@@ -10,7 +11,7 @@ const meta: Meta<typeof Button> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['primary', 'secondary', 'subtle', 'outline', 'ghost', 'danger'],
+      options: ['primary', 'secondary', 'subtle', 'outline', 'ghost', 'danger', 'destructive'],
     },
     size: { control: 'select', options: ['sm', 'md', 'lg'] },
     loading: { control: 'boolean' },
@@ -36,6 +37,7 @@ export const Variants: Story = {
       <Button variant="outline">Outline</Button>
       <Button variant="ghost">Ghost</Button>
       <Button variant="danger">Danger</Button>
+      <Button variant="destructive">Destructive</Button> {/* Додано */}
     </div>
   ),
 };
@@ -95,7 +97,11 @@ export const Disabled: Story = {
     </div>
   ),
 };
+
 export const Destructive: Story = {
+  parameters: {
+    docs: { description: { story: 'Alias for the `danger` variant, used for destructive actions.' } }
+  },
   args: {
     variant: 'destructive',
     children: 'Delete',
@@ -103,9 +109,16 @@ export const Destructive: Story = {
 };
 
 export const AsChild: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Demonstrates polymorphic composition using `asChild`. Example uses a custom `LocaleLink` component.'
+      }
+    }
+  },
   args: {
     asChild: true,
-    children: <a href="#">Custom Link</a>,
+    children: <LocaleLink href="#">Custom Link</LocaleLink>,
   },
 };
 

--- a/src/components/actions/Button/Button.test.tsx
+++ b/src/components/actions/Button/Button.test.tsx
@@ -22,6 +22,13 @@ describe('Button', () => {
     expect(btn.className).toMatch(/size-lg/);
   });
 
+  it('maps the `destructive` variant alias to the danger class', () => {
+    render(<Button variant="destructive">x</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toMatch(/variant-danger/);
+    expect(btn.className).not.toMatch(/variant-destructive/);
+  });
+
   it('fires onClick', () => {
     const onClick = vi.fn();
     render(<Button onClick={onClick}>go</Button>);

--- a/src/components/actions/Button/Button.tsx
+++ b/src/components/actions/Button/Button.tsx
@@ -99,7 +99,7 @@ export const Button = createPolymorphicComponent<ButtonComponent>(
 
   const buttonClassName = classNames(
     styles.button,
-   styles[variant-${variant === 'destructive' ? 'danger' : variant}],
+  styles[\variant-${variant === 'destructive' ? 'danger' : variant}`],
     styles[`size-${size}`],
     iconOnly ? styles.iconOnly : undefined,
     fullWidth ? styles.fullWidth : undefined,

--- a/src/components/actions/Button/Button.tsx
+++ b/src/components/actions/Button/Button.tsx
@@ -7,7 +7,6 @@ import type { PolymorphicProps, PolymorphicRef } from '../../../types/polymorphi
 import { createPolymorphicComponent } from '../../../types/polymorphic';
 import styles from './Button.module.css';
 
-
 export type ButtonVariant = 'primary' | 'secondary' | 'subtle' | 'outline' | 'ghost' | 'danger' | 'destructive';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 

--- a/src/components/actions/Button/Button.tsx
+++ b/src/components/actions/Button/Button.tsx
@@ -7,7 +7,14 @@ import type { PolymorphicProps, PolymorphicRef } from '../../../types/polymorphi
 import { createPolymorphicComponent } from '../../../types/polymorphic';
 import styles from './Button.module.css';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'subtle' | 'outline' | 'ghost' | 'danger' | 'destructive';
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'subtle'
+  | 'outline'
+  | 'ghost'
+  | 'danger'
+  | 'destructive';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
 interface ButtonBaseProps {
@@ -64,104 +71,105 @@ export type ButtonProps =
  */
 export const Button = createPolymorphicComponent<ButtonComponent>(
   forwardRef(function Button(
-  {
-    as,
-    asChild,
-    variant = 'primary',
-    size = 'md',
-    leftIcon,
-    rightIcon,
-    iconOnly,
-    loading,
-    loadingLabel,
-    fullWidth,
-    disabled,
-    type,
-    className,
-    children,
-    'aria-busy': ariaBusy,
-    'aria-label': ariaLabel,
-    ...rest
-  }: PolymorphicProps<
-    React.ElementType,
-    ButtonBaseProps & {
-      iconOnly?: boolean;
-      disabled?: boolean;
-      type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
-      'aria-busy'?: React.AriaAttributes['aria-busy'];
-      'aria-label'?: string;
+    {
+      as,
+      asChild,
+      variant = 'primary',
+      size = 'md',
+      leftIcon,
+      rightIcon,
+      iconOnly,
+      loading,
+      loadingLabel,
+      fullWidth,
+      disabled,
+      type,
+      className,
+      children,
+      'aria-busy': ariaBusy,
+      'aria-label': ariaLabel,
+      ...rest
+    }: PolymorphicProps<
+      React.ElementType,
+      ButtonBaseProps & {
+        iconOnly?: boolean;
+        disabled?: boolean;
+        type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
+        'aria-busy'?: React.AriaAttributes['aria-busy'];
+        'aria-label'?: string;
+      }
+    >,
+    ref: React.ForwardedRef<Element>
+  ) {
+    const isDisabled = Boolean(disabled || loading);
+    const resolvedAriaLabel = loading && loadingLabel ? loadingLabel : ariaLabel;
+    const resolvedVariant = variant === 'destructive' ? 'danger' : variant;
+
+    const buttonClassName = classNames(
+      styles.button,
+      styles[`variant-${resolvedVariant}`],
+      styles[`size-${size}`],
+      iconOnly ? styles.iconOnly : undefined,
+      fullWidth ? styles.fullWidth : undefined,
+      className
+    );
+
+    // asChild: merge button styles onto the single child element.
+    if (asChild) {
+      return (
+        <Slot
+          ref={ref}
+          className={buttonClassName}
+          aria-busy={loading ? true : ariaBusy}
+          aria-label={resolvedAriaLabel}
+          {...(isDisabled ? { 'aria-disabled': true, 'data-disabled': '' } : {})}
+          {...rest}
+        >
+          {children}
+        </Slot>
+      );
     }
-  >,
-  ref: React.ForwardedRef<Element>
-) {
-  const isDisabled = Boolean(disabled || loading);
-  const resolvedAriaLabel = loading && loadingLabel ? loadingLabel : ariaLabel;
 
-  const buttonClassName = classNames(
-    styles.button,
-  styles[\variant-${variant === 'destructive' ? 'danger' : variant}`],
-    styles[`size-${size}`],
-    iconOnly ? styles.iconOnly : undefined,
-    fullWidth ? styles.fullWidth : undefined,
-    className
-  );
+    const Component: React.ElementType = as ?? 'button';
+    const isNativeButton = Component === 'button';
 
-  // asChild: merge button styles onto the single child element.
-  if (asChild) {
+    let extraButtonProps: Record<string, unknown>;
+    if (isNativeButton) {
+      extraButtonProps = { type: type ?? 'button', disabled: isDisabled };
+    } else if (isDisabled) {
+      extraButtonProps = { 'aria-disabled': true, 'data-disabled': '' };
+    } else {
+      extraButtonProps = {};
+    }
+
     return (
-      <Slot
+      <Component
         ref={ref}
-        className={buttonClassName}
+        {...extraButtonProps}
         aria-busy={loading ? true : ariaBusy}
         aria-label={resolvedAriaLabel}
-        {...(isDisabled ? { 'aria-disabled': true, 'data-disabled': '' } : {})}
+        className={buttonClassName}
         {...rest}
       >
-        {children}
-      </Slot>
+        {loading && (
+          <Spinner
+            size="sm"
+            label=""
+            className={styles.spinner}
+            data-testid="button-spinner"
+            aria-hidden="true"
+          />
+        )}
+        <span
+          className={classNames(loading ? styles.contentHidden : undefined)}
+          style={{ display: 'inline-flex', alignItems: 'center', gap: 'inherit' }}
+        >
+          {leftIcon && <span aria-hidden="true">{leftIcon}</span>}
+          {children}
+          {rightIcon && <span aria-hidden="true">{rightIcon}</span>}
+        </span>
+      </Component>
     );
-  }
-
-  const Component: React.ElementType = as ?? 'button';
-  const isNativeButton = Component === 'button';
-
-  let extraButtonProps: Record<string, unknown>;
-  if (isNativeButton) {
-    extraButtonProps = { type: type ?? 'button', disabled: isDisabled };
-  } else if (isDisabled) {
-    extraButtonProps = { 'aria-disabled': true, 'data-disabled': '' };
-  } else {
-    extraButtonProps = {};
-  }
-
-  return (
-    <Component
-      ref={ref}
-      {...extraButtonProps}
-      aria-busy={loading ? true : ariaBusy}
-      aria-label={resolvedAriaLabel}
-      className={buttonClassName}
-      {...rest}
-    >
-      {loading && (
-        <Spinner
-          size="sm"
-          label=""
-          className={styles.spinner}
-          data-testid="button-spinner"
-          aria-hidden="true"
-        />
-      )}
-      <span
-        className={classNames(loading ? styles.contentHidden : undefined)}
-        style={{ display: 'inline-flex', alignItems: 'center', gap: 'inherit' }}
-      >
-        {leftIcon && <span aria-hidden="true">{leftIcon}</span>}
-        {children}
-        {rightIcon && <span aria-hidden="true">{rightIcon}</span>}
-      </span>
-    </Component>
-  );
-}),
-'Button'
+  }),
+  'Button'
 );

--- a/src/components/actions/Button/Button.tsx
+++ b/src/components/actions/Button/Button.tsx
@@ -7,7 +7,8 @@ import type { PolymorphicProps, PolymorphicRef } from '../../../types/polymorphi
 import { createPolymorphicComponent } from '../../../types/polymorphic';
 import styles from './Button.module.css';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'subtle' | 'outline' | 'ghost' | 'danger';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'subtle' | 'outline' | 'ghost' | 'danger' | 'destructive';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
 interface ButtonBaseProps {
@@ -99,7 +100,7 @@ export const Button = createPolymorphicComponent<ButtonComponent>(
 
   const buttonClassName = classNames(
     styles.button,
-    styles[`variant-${variant}`],
+   styles[variant-${variant === 'destructive' ? 'danger' : variant}],
     styles[`size-${size}`],
     iconOnly ? styles.iconOnly : undefined,
     fullWidth ? styles.fullWidth : undefined,


### PR DESCRIPTION
Closes #115

Description
This PR adds the destructive variant as an alias for danger in the Button component for better migration clarity. It also updates the Storybook documentation to showcase both the new destructive variant and the asChild composition.

Changes
Button.tsx: Added destructive to ButtonVariant type and mapped it to the danger styles.

Button.stories.tsx: Added Destructive and AsChild stories to the documentation.

Checklist
[x] Added destructive alias.

[x] Updated Storybook documentation.

[x] Verified composition with asChild.